### PR TITLE
fix: Explicitly use cash basis accounting for Xero P&L

### DIFF
--- a/apps/api/src/xero/client.ts
+++ b/apps/api/src/xero/client.ts
@@ -24,6 +24,7 @@ export async function getProfitAndLoss(
   const params = new URLSearchParams({
     fromDate: startDate,
     toDate: endDate,
+    paymentsOnly: 'true',
   });
   const url = `${base}?${params.toString()}`;
   const resp = await fetch(url, {

--- a/apps/api/src/xero/client.ts
+++ b/apps/api/src/xero/client.ts
@@ -6,11 +6,15 @@ export async function getAccounts(accessToken: string, tenantId: string) {
       Accept: "application/json",
     },
   });
+  const text = await resp.text();
   if (!resp.ok) {
-    const text = await resp.text();
     throw new Error(`Xero accounts failed: ${resp.status} ${text}`);
   }
-  return await resp.json();
+  try {
+    return JSON.parse(text);
+  } catch {
+    throw new Error(`Xero accounts returned invalid JSON (status ${resp.status}): ${text.slice(0, 200)}`);
+  }
 }
 
 export async function getProfitAndLoss(
@@ -34,9 +38,13 @@ export async function getProfitAndLoss(
       Accept: "application/json",
     },
   });
+  const text = await resp.text();
   if (!resp.ok) {
-    const text = await resp.text();
     throw new Error(`Xero P&L failed: ${resp.status} ${text}`);
   }
-  return await resp.json();
+  try {
+    return JSON.parse(text);
+  } catch {
+    throw new Error(`Xero P&L returned invalid JSON (status ${resp.status}): ${text.slice(0, 200)}`);
+  }
 }

--- a/apps/api/src/xero/routes.ts
+++ b/apps/api/src/xero/routes.ts
@@ -107,7 +107,12 @@ xero.post('/pnl', async (c) => {
   const categories: Record<string, number> = {};
   const uncategorized: UncategorizedItem[] = [];
 
-  const rows: XeroPnlRow[] = data?.Reports?.[0]?.Rows || [];
+  if (!data?.Reports?.[0]) {
+    console.error('[Xero] P&L response missing Reports data:', JSON.stringify(data).slice(0, 500));
+    return c.json({ error: 'Xero returned an unexpected P&L response format' }, 502);
+  }
+
+  const rows: XeroPnlRow[] = data.Reports[0].Rows || [];
 
   const parseAmount = (s: string | number | undefined | null): number => {
     if (s == null) return 0;

--- a/apps/api/src/xero/routes.ts
+++ b/apps/api/src/xero/routes.ts
@@ -195,7 +195,7 @@ xero.post('/pnl', async (c) => {
     raw: data ?? undefined,
   };
   // Save snapshot
-  await supabaseService
+  const { error: upsertErr } = await supabaseService
     .from('xero_pnl_snapshots')
     .upsert({
       tenant_id: creds.tenant_id,
@@ -204,5 +204,8 @@ xero.post('/pnl', async (c) => {
       result_json: result,
       updated_at: new Date().toISOString(),
     }, { onConflict: 'tenant_id,start_date,end_date' });
+  if (upsertErr) {
+    console.error('[Xero] Failed to save P&L snapshot:', upsertErr.message);
+  }
   return c.json({ ...result, meta: { cached: false, lastUpdated: new Date().toISOString() } });
 });

--- a/apps/api/src/xero/routes.ts
+++ b/apps/api/src/xero/routes.ts
@@ -78,6 +78,9 @@ xero.post('/pnl', async (c) => {
       .eq('start_date', input.data.startDate)
       .eq('end_date', input.data.endDate)
       .maybeSingle();
+    if (snapErr) {
+      console.error('[Xero] Snapshot cache read failed, falling back to live fetch:', snapErr.message);
+    }
     if (!snapErr && existing?.result_json) {
       const withMeta = { ...existing.result_json, meta: { cached: true, lastUpdated: existing.updated_at } };
       return c.json(withMeta);


### PR DESCRIPTION
## Summary
- Explicitly set `paymentsOnly=true` on Xero P&L API requests to ensure cash basis accounting
- Previously relied on Xero's default, which was returning accrual basis figures
- Fixes incorrect Security and COGS values in the app and business performance emails

## Test plan
- [ ] Refresh P&L data in the app and verify Security includes Crowd Controllers
- [ ] Verify COGS matches the cash basis figure from Xero
- [ ] Verify Wages still includes Superannuation correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)