### PR TITLE
feat: Add benchmarks to performance email + targeted test sends

### DIFF
--- a/src/components/settings/NotificationSettings.tsx
+++ b/src/components/settings/NotificationSettings.tsx
@@ -109,17 +109,25 @@ export function NotificationSettings() {
     }
   }
 
-  async function testNotification(type: 'trade_report' | 'business_performance', method: 'email' | 'whatsapp') {
+  async function testNotification(type: 'trade_report' | 'business_performance', method: 'email' | 'whatsapp', recipient?: string) {
     const settings = type === 'trade_report' ? tradeReportSettings : businessPerfSettings;
     const functionName = type === 'trade_report' ? 'trade-report' : 'business-performance';
 
     if (!settings) return;
 
-    const recipients = method === 'email' ? settings.recipient_emails : settings.whatsapp_numbers;
-    if (recipients.length === 0) {
+    if (method === 'email' && !recipient) {
+      toast({
+        title: 'No Recipient',
+        description: 'Please enter an email address for the test',
+        variant: 'destructive',
+      });
+      return;
+    }
+
+    if (method === 'whatsapp' && settings.whatsapp_numbers.length === 0) {
       toast({
         title: 'No Recipients',
-        description: `Please add at least one ${method === 'email' ? 'email' : 'WhatsApp number'} first`,
+        description: 'Please add at least one WhatsApp number first',
         variant: 'destructive',
       });
       return;
@@ -133,6 +141,7 @@ export function NotificationSettings() {
         body: {
           test_email_only: method === 'email',
           test_whatsapp_only: method === 'whatsapp',
+          ...(method === 'email' && recipient ? { test_recipient: recipient } : {}),
         },
       });
 
@@ -140,7 +149,9 @@ export function NotificationSettings() {
 
       toast({
         title: 'Success',
-        description: `Test ${method} sent to ${recipients.length} recipient(s)`,
+        description: method === 'email'
+          ? `Test email sent to ${recipient}`
+          : `Test WhatsApp sent to ${settings.whatsapp_numbers.length} recipient(s)`,
       });
     } catch (error) {
       console.error(`Error sending test ${method}:`, error);
@@ -286,7 +297,7 @@ export function NotificationSettings() {
             functionName="trade-report"
             onUpdate={setTradeReportSettings}
             onSave={() => saveSettings('trade_report')}
-            onTest={(method) => testNotification('trade_report', method)}
+            onTest={(method, recipient) => testNotification('trade_report', method, recipient)}
             onPreview={() => previewNotification('trade_report')}
             onScheduleChange={(day, hour) => updateSchedule('trade_report', day, hour)}
             saving={saving.tradeReport}
@@ -304,7 +315,7 @@ export function NotificationSettings() {
             functionName="business-performance"
             onUpdate={setBusinessPerfSettings}
             onSave={() => saveSettings('business_performance')}
-            onTest={(method) => testNotification('business_performance', method)}
+            onTest={(method, recipient) => testNotification('business_performance', method, recipient)}
             onPreview={() => previewNotification('business_performance')}
             onScheduleChange={(day, hour) => updateSchedule('business_performance', day, hour)}
             saving={saving.businessPerf}

--- a/src/components/settings/notifications/NotificationCard.tsx
+++ b/src/components/settings/notifications/NotificationCard.tsx
@@ -30,7 +30,7 @@ interface NotificationCardProps {
   functionName: string;
   onUpdate: (settings: NotificationSettingsData) => void;
   onSave: () => void;
-  onTest: (type: 'email' | 'whatsapp') => void;
+  onTest: (type: 'email' | 'whatsapp', recipient?: string) => void;
   onPreview: () => void;
   onScheduleChange: (dayOfWeek: number, hourAwst: number) => void;
   saving: boolean;
@@ -55,6 +55,7 @@ export function NotificationCard({
 }: NotificationCardProps) {
   const [newEmail, setNewEmail] = useState('');
   const [newPhone, setNewPhone] = useState('');
+  const [testEmail, setTestEmail] = useState('');
   const [tempDayOfWeek, setTempDayOfWeek] = useState<number>(settings.schedule_day_of_week ?? 0);
   const [tempHourAwst, setTempHourAwst] = useState<number>(settings.schedule_hour_awst ?? 6);
   const { toast } = useToast();
@@ -356,24 +357,6 @@ export function NotificationCard({
               )}
             </Button>
             <Button
-              onClick={() => onTest('email')}
-              variant="outline"
-              disabled={testing.email || !settings.enabled || settings.recipient_emails.length === 0}
-              className="flex-1"
-            >
-              {testing.email ? (
-                <>
-                  <Loader2 className="mr-2 h-4 w-4 animate-spin" />
-                  Sending...
-                </>
-              ) : (
-                <>
-                  <Send className="mr-2 h-4 w-4" />
-                  Test Email
-                </>
-              )}
-            </Button>
-            <Button
               onClick={() => onTest('whatsapp')}
               variant="outline"
               disabled={testing.whatsapp || !settings.enabled || settings.whatsapp_numbers.length === 0}
@@ -388,6 +371,40 @@ export function NotificationCard({
                 <>
                   <Send className="mr-2 h-4 w-4" />
                   Test WhatsApp
+                </>
+              )}
+            </Button>
+          </div>
+          <div className="flex space-x-2">
+            <Input
+              type="email"
+              placeholder="Enter email for test send"
+              value={testEmail}
+              onChange={(e) => setTestEmail(e.target.value)}
+              onKeyDown={(e) => {
+                if (e.key === 'Enter') {
+                  e.preventDefault();
+                  if (testEmail && /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(testEmail)) {
+                    onTest('email', testEmail);
+                  }
+                }
+              }}
+              disabled={testing.email || !settings.enabled}
+            />
+            <Button
+              onClick={() => onTest('email', testEmail)}
+              variant="outline"
+              disabled={testing.email || !settings.enabled || !testEmail || !/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(testEmail)}
+            >
+              {testing.email ? (
+                <>
+                  <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                  Sending...
+                </>
+              ) : (
+                <>
+                  <Send className="mr-2 h-4 w-4" />
+                  Send Test Email
                 </>
               )}
             </Button>

--- a/supabase/functions/business-performance/index.ts
+++ b/supabase/functions/business-performance/index.ts
@@ -893,6 +893,7 @@ serve(async (req: Request) => {
     const body = await req.json().catch(() => ({}))
     const testEmailOnly = body.test_email_only === true
     const testWhatsAppOnly = body.test_whatsapp_only === true
+    const testRecipient = typeof body.test_recipient === 'string' ? body.test_recipient : null
     const previewOnly = body.preview_only === true
 
     // Fetch notification settings
@@ -966,12 +967,13 @@ serve(async (req: Request) => {
 
     // Generate and send emails (only if not in WhatsApp-only test mode)
     const emailResults: { recipient: string; success: boolean }[] = []
-    if (!testWhatsAppOnly && notificationSettings.recipient_emails && notificationSettings.recipient_emails.length > 0) {
+    const emailRecipients = testRecipient ? [testRecipient] : (notificationSettings.recipient_emails || [])
+    if (!testWhatsAppOnly && emailRecipients.length > 0) {
       console.log('Generating email HTML...')
       const emailHtml = generateEmailHtml(performanceData)
       const subject = `Weekly Performance Report - ${performanceData.saturdayLabels.current.replace('Saturday - ', '')}`
 
-      for (const email of notificationSettings.recipient_emails) {
+      for (const email of emailRecipients) {
         console.log(`Sending email to ${email}...`)
         const success = await sendEmail(supabase, email, subject, emailHtml)
         emailResults.push({ recipient: email, success })

--- a/supabase/functions/business-performance/index.ts
+++ b/supabase/functions/business-performance/index.ts
@@ -71,6 +71,11 @@ interface BusinessPerformanceData {
     attendance: number
     spendPerHead: number
   }
+  benchmarks: {
+    wages: number
+    cogs: number
+    security: number
+  }
   changes: {
     revenuePercent: number
     revenueVsAvg: number
@@ -298,6 +303,17 @@ async function fetchRevenueAndAttendance(
 async function fetchBusinessPerformanceData(supabase: any): Promise<BusinessPerformanceData> {
   const dateRanges = calculateDateRanges()
 
+  // Fetch benchmarks
+  const { data: benchmarkRows } = await supabase
+    .from('cost_benchmarks')
+    .select('category, benchmark_percent')
+  const benchmarks = { wages: 0, cogs: 0, security: 0 }
+  for (const row of benchmarkRows || []) {
+    if (row.category === 'wages' || row.category === 'cogs' || row.category === 'security') {
+      benchmarks[row.category] = Number(row.benchmark_percent) || 0
+    }
+  }
+
   // Fetch P&L and revenue/attendance for current, previous, year-ago, and 4 averaging weeks
   const [currentPnl, previousPnl, yearAgoPnl, currentMetrics, previousMetrics, yearAgoMetrics, ...avgData] = await Promise.all([
     fetchPnlData(supabase, dateRanges.currentStart, dateRanges.currentEnd),
@@ -446,6 +462,7 @@ async function fetchBusinessPerformanceData(supabase: any): Promise<BusinessPerf
       end: formatDate(dateRanges.currentEnd),
     },
     saturdayLabels,
+    benchmarks,
     current: {
       revenue: Math.round(displayCurrentRevenue * 100), // Store as cents for formatCurrency
       wages: Math.round(currentWages * 100),
@@ -523,9 +540,9 @@ function generateWhatsAppMessage(data: BusinessPerformanceData): string {
 
 ${data.saturdayLabels.current}
 Revenue - ${formatCurrency(data.current.revenue)} (${formatChange(data.changes.revenueVsAvg)} vs avg)
-Wages - ${formatCurrency(data.current.wages)} (${data.current.wagesPercent.toFixed(1)}%, ${formatChange(data.changes.wagesVsAvg)} vs avg)
-COGS - ${formatCurrency(data.current.cogs)} (${data.current.cogsPercent.toFixed(1)}%, ${formatChange(data.changes.cogsVsAvg)} vs avg)
-Security - ${formatCurrency(data.current.security)} (${data.current.securityPercent.toFixed(1)}%, ${formatChange(data.changes.securityVsAvg)} vs avg)
+Wages - ${formatCurrency(data.current.wages)} (${data.current.wagesPercent.toFixed(1)}%${data.benchmarks.wages ? ` vs ${data.benchmarks.wages}% target` : ''}, ${formatChange(data.changes.wagesVsAvg)} vs avg)
+COGS - ${formatCurrency(data.current.cogs)} (${data.current.cogsPercent.toFixed(1)}%${data.benchmarks.cogs ? ` vs ${data.benchmarks.cogs}% target` : ''}, ${formatChange(data.changes.cogsVsAvg)} vs avg)
+Security - ${formatCurrency(data.current.security)} (${data.current.securityPercent.toFixed(1)}%${data.benchmarks.security ? ` vs ${data.benchmarks.security}% target` : ''}, ${formatChange(data.changes.securityVsAvg)} vs avg)
 Attendance - ${data.current.attendance.toLocaleString()} (${formatChange(data.changes.attendanceVsAvg)} vs avg)
 Spend Per Head - ${formatCurrency(data.current.spendPerHead)} (${formatChange(data.changes.spendPerHeadVsAvg)} vs avg)
 
@@ -660,7 +677,7 @@ function generateEmailHtml(data: BusinessPerformanceData): string {
     {
       metric: 'Wages',
       value: formatCurrency(data.current.wages),
-      valueSuffix: ` <span style="color:#94a3b8;font-family:'JetBrains Mono',monospace;font-size:13px;">(${data.current.wagesPercent.toFixed(1)}%)</span>`,
+      valueSuffix: ` <span style="color:#94a3b8;font-family:'JetBrains Mono',monospace;font-size:13px;">(${data.current.wagesPercent.toFixed(1)}%${data.benchmarks.wages ? ` vs ${data.benchmarks.wages}%` : ''})</span>`,
       wow: generateIndicator(data.changes.wagesPercentChange, true, true),
       vsAvg: generateIndicator(data.changes.wagesVsAvg, true, avgCostDataAvailable),
       yoy: generateIndicator(data.changes.wagesYoY, true, yoyCostDataAvailable),
@@ -668,7 +685,7 @@ function generateEmailHtml(data: BusinessPerformanceData): string {
     {
       metric: 'COGS',
       value: formatCurrency(data.current.cogs),
-      valueSuffix: ` <span style="color:#94a3b8;font-family:'JetBrains Mono',monospace;font-size:13px;">(${data.current.cogsPercent.toFixed(1)}%)</span>`,
+      valueSuffix: ` <span style="color:#94a3b8;font-family:'JetBrains Mono',monospace;font-size:13px;">(${data.current.cogsPercent.toFixed(1)}%${data.benchmarks.cogs ? ` vs ${data.benchmarks.cogs}%` : ''})</span>`,
       wow: generateIndicator(data.changes.cogsPercentChange, true, true),
       vsAvg: generateIndicator(data.changes.cogsVsAvg, true, avgCostDataAvailable),
       yoy: generateIndicator(data.changes.cogsYoY, true, yoyCostDataAvailable),
@@ -676,7 +693,7 @@ function generateEmailHtml(data: BusinessPerformanceData): string {
     {
       metric: 'Security',
       value: formatCurrency(data.current.security),
-      valueSuffix: ` <span style="color:#94a3b8;font-family:'JetBrains Mono',monospace;font-size:13px;">(${data.current.securityPercent.toFixed(1)}%)</span>`,
+      valueSuffix: ` <span style="color:#94a3b8;font-family:'JetBrains Mono',monospace;font-size:13px;">(${data.current.securityPercent.toFixed(1)}%${data.benchmarks.security ? ` vs ${data.benchmarks.security}%` : ''})</span>`,
       wow: generateIndicator(data.changes.securityPercentChange, true, true),
       vsAvg: generateIndicator(data.changes.securityVsAvg, true, avgCostDataAvailable),
       yoy: generateIndicator(data.changes.securityYoY, true, yoyCostDataAvailable),

--- a/supabase/functions/trade-report/index.ts
+++ b/supabase/functions/trade-report/index.ts
@@ -749,6 +749,7 @@ serve(async (req: Request) => {
     const body = await req.json().catch(() => ({}))
     const testEmailOnly = body.test_email_only === true
     const testWhatsAppOnly = body.test_whatsapp_only === true
+    const testRecipient = typeof body.test_recipient === 'string' ? body.test_recipient : null
     const previewOnly = body.preview_only === true
 
     // Fetch notification settings
@@ -822,12 +823,13 @@ serve(async (req: Request) => {
 
     // Generate and send emails (only if not in WhatsApp-only test mode)
     const emailResults: { recipient: string; success: boolean }[] = []
-    if (!testWhatsAppOnly && notificationSettings.recipient_emails && notificationSettings.recipient_emails.length > 0) {
+    const emailRecipients = testRecipient ? [testRecipient] : (notificationSettings.recipient_emails || [])
+    if (!testWhatsAppOnly && emailRecipients.length > 0) {
       console.log('Generating email content...')
       const emailHtml = generateEmailHtml(summaryData)
       const subject = `Saturday Trade Report - ${summaryData.saturdayLabels.current.replace('Saturday - ', '')}`
 
-      for (const email of notificationSettings.recipient_emails) {
+      for (const email of emailRecipients) {
         console.log(`Sending email to ${email}...`)
         const success = await sendEmail(email, subject, emailHtml)
         emailResults.push({ recipient: email, success })


### PR DESCRIPTION
## Summary
- **Benchmark targets in weekly email**: Cost rows (Wages, COGS, Security) now show the configured benchmark alongside the actual percentage — e.g. `(32.5% vs 30%)` in email, `(32.5% vs 30% target)` in WhatsApp. When benchmarks are 0 (unconfigured), output is unchanged. Reads from the existing `cost_benchmarks` table.
- **Targeted test email sends**: Replaced the "Test Email" button with an email input field so test notifications go to a single specified address instead of the entire recipient list. Applies to both trade-report and business-performance edge functions.

## Test plan
- [ ] Set non-zero benchmarks in Settings → verify they appear in email preview and test send
- [ ] Leave benchmarks at 0 → verify email looks identical to before
- [ ] Enter a test email address → verify only that address receives the notification
- [ ] Test WhatsApp button still works as before
- [ ] Check mobile rendering (no column overflow from longer percentage text)

🤖 Generated with [Claude Code](https://claude.com/claude-code)